### PR TITLE
feat: add module to create Boundary controllers

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,8 @@
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+  format  = "snake_case"
+}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,3 +1,7 @@
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
 rule "terraform_documented_variables" {
   enabled = true
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,9 @@ provider "aws" {}
 locals {
   image_id = data.aws_ami.boundary.id
 
-  subnets = coalescelist(var.subnets, module.vpc.public_subnets)
+  private_subnets = coalescelist(var.private_subnets, module.vpc.private_subnets)
+
+  public_subnets = coalescelist(var.public_subnets, module.vpc.public_subnets)
 
   tags = merge(
     var.tags,
@@ -13,8 +15,6 @@ locals {
   )
 
   vpc_id = coalesce(var.vpc_id, module.vpc.vpc_id)
-
-  vpc_zone_identifier = coalescelist(var.vpc_zone_identifier, module.vpc.private_subnets)
 }
 
 data "aws_availability_zones" "available" {}
@@ -28,16 +28,16 @@ data "aws_ami" "boundary" {
 module "controllers" {
   source = "./modules/controller"
 
-  boundary_release    = var.boundary_release
-  desired_capacity    = var.controller_desired_capacity
-  image_id            = local.image_id
-  instance_type       = var.controller_instance_type
-  max_size            = var.controller_max_size
-  min_size            = var.controller_min_size
-  subnets             = local.subnets
-  tags                = local.tags
-  vpc_id              = local.vpc_id
-  vpc_zone_identifier = local.vpc_zone_identifier
+  boundary_release = var.boundary_release
+  desired_capacity = var.controller_desired_capacity
+  image_id         = local.image_id
+  instance_type    = var.controller_instance_type
+  max_size         = var.controller_max_size
+  min_size         = var.controller_min_size
+  private_subnets  = local.private_subnets
+  public_subnets   = local.public_subnets
+  tags             = local.tags
+  vpc_id           = local.vpc_id
 }
 
 module "vpc" {

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,65 @@
+provider "aws" {}
+
+locals {
+  image_id = data.aws_ami.boundary.id
+
+  subnets = coalescelist(var.subnets, module.vpc.public_subnets)
+
+  tags = merge(
+    var.tags,
+    {
+      Owner = "terraform"
+    }
+  )
+
+  vpc_id = coalesce(var.vpc_id, module.vpc.vpc_id)
+
+  vpc_zone_identifier = coalescelist(var.vpc_zone_identifier, module.vpc.private_subnets)
+}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_ami" "boundary" {
+  most_recent = true
+  name_regex  = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
+  owners      = ["aws-marketplace"]
+}
+
+module "controllers" {
+  source = "./modules/controller"
+
+  boundary_release    = var.boundary_release
+  desired_capacity    = var.controller_desired_capacity
+  image_id            = local.image_id
+  instance_type       = var.controller_instance_type
+  max_size            = var.controller_max_size
+  min_size            = var.controller_min_size
+  subnets             = local.subnets
+  tags                = local.tags
+  vpc_id              = local.vpc_id
+  vpc_zone_identifier = local.vpc_zone_identifier
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  azs                = data.aws_availability_zones.available.names
+  cidr               = var.cidr_block
+  create_vpc         = var.vpc_id != "" ? false : true
+  enable_nat_gateway = true
+  name               = "boundary"
+
+  private_subnets = [
+    "10.0.1.0/24",
+    "10.0.2.0/24",
+    "10.0.3.0/24"
+  ]
+
+  public_subnets = [
+    "10.0.101.0/24",
+    "10.0.102.0/24",
+    "10.0.103.0/24"
+  ]
+
+  tags = local.tags
+}

--- a/modules/boundary/files/boundary.service
+++ b/modules/boundary/files/boundary.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Access any system from anywhere based on user identity
+Documentation=https://www.boundaryproject.io/docs
+
+[Service]
+ExecStart=/usr/local/bin/boundary server -config /etc/boundary/configuration.hcl
+LimitMEMLOCK=infinity
+Capabilities=CAP_IPC_LOCK+ep
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/boundary/main.tf
+++ b/modules/boundary/main.tf
@@ -1,0 +1,64 @@
+locals {
+  desired_capacity = max(var.desired_capacity, var.min_size)
+
+  download_url = format(
+    "https://releases.hashicorp.com/boundary/%s/boundary_%s_linux_amd64.zip",
+    var.boundary_release,
+    var.boundary_release
+  )
+
+  user_data = {
+    package_update = true
+    packages       = ["unzip"]
+
+    runcmd = concat(
+      [
+        "wget -O boundary.zip ${local.download_url}",
+        "unzip boundary.zip -d /usr/local/bin"
+      ],
+      var.runcmd,
+      [
+        "systemctl enable boundary",
+        "systemctl start boundary"
+      ]
+    )
+
+    write_files = concat(
+      [
+        {
+          content     = base64encode(file("${path.module}/files/boundary.service"))
+          encoding    = "b64"
+          owner       = "root:root"
+          path        = "/etc/systemd/system/boundary.service"
+          permissions = "0644"
+        }
+      ],
+      var.write_files
+    )
+  }
+}
+
+module "autoscaling" {
+  source = "terraform-aws-modules/autoscaling/aws"
+
+  desired_capacity             = local.desired_capacity
+  health_check_type            = "EC2"
+  iam_instance_profile         = var.iam_instance_profile
+  image_id                     = var.image_id
+  instance_type                = var.instance_type
+  key_name                     = var.key_name
+  max_size                     = var.max_size
+  min_size                     = var.min_size
+  name                         = var.auto_scaling_group_name
+  recreate_asg_when_lc_changes = true
+  security_groups              = var.security_groups
+  tags_as_map                  = var.tags
+  target_group_arns            = var.target_group_arns
+
+  user_data = <<EOF
+#cloud-config
+${yamlencode(local.user_data)}
+EOF
+
+  vpc_zone_identifier = var.vpc_zone_identifier
+}

--- a/modules/boundary/variables.tf
+++ b/modules/boundary/variables.tf
@@ -4,7 +4,7 @@ variable "auto_scaling_group_name" {
 }
 
 variable "boundary_release" {
-  description = ""
+  description = "The version of Boundary to install"
   type        = string
 }
 
@@ -30,8 +30,11 @@ EOF
 }
 
 variable "image_id" {
-  description = ""
-  type        = string
+  description = <<EOF
+The ID of the Amazon Machine Image (AMI) that was assigned during registration
+EOF
+
+  type = string
 }
 
 variable "instance_type" {
@@ -56,9 +59,14 @@ variable "min_size" {
 }
 
 variable "runcmd" {
-  default     = []
-  description = ""
-  type        = list(string)
+  default = []
+
+  description = <<EOF
+Run arbitrary commands at a rc.local like level with output to the
+console. Each item can be either a list or a string.
+EOF
+
+  type = list(string)
 }
 
 variable "security_groups" {
@@ -104,7 +112,7 @@ EOF
 
 variable "write_files" {
   default     = []
-  description = ""
+  description = "Write out arbitrary content to files, optionally setting permissions"
 
   type = list(object({
     content     = string

--- a/modules/boundary/variables.tf
+++ b/modules/boundary/variables.tf
@@ -1,0 +1,116 @@
+variable "auto_scaling_group_name" {
+  description = "The name of the Auto Scaling group"
+  type        = string
+}
+
+variable "boundary_release" {
+  description = ""
+  type        = string
+}
+
+variable "desired_capacity" {
+  default = 0
+
+  description = <<EOF
+The desired capacity is the initial capacity of the Auto Scaling group
+at the time of its creation and the capacity it attempts to maintain.
+EOF
+
+  type = number
+}
+
+variable "iam_instance_profile" {
+  default = ""
+
+  description = <<EOF
+The name or the Amazon Resource Name (ARN) of the instance profile associated
+with the IAM role for the instance
+EOF
+  type        = string
+}
+
+variable "image_id" {
+  description = ""
+  type        = string
+}
+
+variable "instance_type" {
+  description = "Specifies the instance type of the EC2 instance"
+  type        = string
+}
+
+variable "key_name" {
+  default     = ""
+  description = "The name of the key pair"
+  type        = string
+}
+
+variable "max_size" {
+  description = "The maximum size of the group"
+  type        = number
+}
+
+variable "min_size" {
+  description = "The minimum size of the group"
+  type        = number
+}
+
+variable "runcmd" {
+  default     = []
+  description = ""
+  type        = list(string)
+}
+
+variable "security_groups" {
+  default = []
+
+  description = <<EOF
+A list that contains the security groups to assign to the instances in the Auto
+Scaling group
+EOF
+
+  type = list(string)
+}
+
+variable "tags" {
+  default = {}
+
+  description = <<EOF
+One or more tags. You can tag your Auto Scaling group and propagate the tags to
+the Amazon EC2 instances it launches.
+EOF
+
+  type = map(string)
+}
+
+variable "target_group_arns" {
+  default = []
+
+  description = <<EOF
+The Amazon Resource Names (ARN) of the target groups to associate with the Auto
+Scaling group
+EOF
+
+  type = list(string)
+}
+
+variable "vpc_zone_identifier" {
+  description = <<EOF
+A comma-separated list of subnet IDs for your virtual private cloud
+EOF
+
+  type = list(string)
+}
+
+variable "write_files" {
+  default     = []
+  description = ""
+
+  type = list(object({
+    content     = string
+    encoding    = string
+    owner       = string
+    path        = string
+    permissions = string
+  }))
+}

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -1,0 +1,224 @@
+locals {
+  configuration = templatefile(
+    "${path.module}/templates/configuration.hcl.tpl",
+    {
+      # Database URL for PostgreSQL
+      database_url = format(
+        "postgresql://%s:%s@%s/%s",
+        module.postgresql.this_db_instance_username,
+        module.postgresql.this_db_instance_password,
+        module.postgresql.this_db_instance_endpoint,
+        module.postgresql.this_db_instance_name
+      )
+
+      kms_key_id = aws_kms_key.boundary.key_id
+    }
+  )
+}
+
+resource "aws_security_group" "alb" {
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  dynamic "ingress" {
+    for_each = [80, 443]
+
+    content {
+      cidr_blocks = ["0.0.0.0/0"]
+      from_port   = ingress.value
+      protocol    = "TCP"
+      to_port     = ingress.value
+    }
+  }
+
+  name = "Boundary Application Load Balancer"
+
+  tags = merge(
+    {
+      Name = "Boundary Application Load Balancer"
+    },
+    var.tags
+  )
+
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group" "controller" {
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  ingress {
+    from_port       = 9200
+    protocol        = "TCP"
+    security_groups = [aws_security_group.alb.id]
+    to_port         = 9200
+  }
+
+  name   = "Boundary controller"
+  tags   = var.tags
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group" "postgresql" {
+  ingress {
+    from_port       = 5432
+    protocol        = "TCP"
+    security_groups = [aws_security_group.controller.id]
+    to_port         = 5432
+  }
+
+  tags   = var.tags
+  vpc_id = var.vpc_id
+}
+
+module "alb" {
+  source = "terraform-aws-modules/alb/aws"
+
+  http_tcp_listeners = [
+    {
+      port     = 80
+      protocol = "HTTP"
+    }
+  ]
+
+  load_balancer_type = "application"
+  name               = "boundary"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.subnets
+  tags               = var.tags
+
+  target_groups = [
+    {
+      name             = "boundary"
+      backend_protocol = "HTTP"
+      backend_port     = 9200
+    }
+  ]
+
+  vpc_id = var.vpc_id
+}
+
+resource "random_password" "postgresql" {
+  length  = 16
+  special = false
+}
+
+module "postgresql" {
+  source = "terraform-aws-modules/rds/aws"
+
+  allocated_storage       = 5
+  backup_retention_period = 0
+  backup_window           = "03:00-06:00"
+  engine                  = "postgres"
+  engine_version          = "12.4"
+  family                  = "postgres12"
+  identifier              = "boundary"
+  instance_class          = "db.t2.micro"
+  maintenance_window      = "Mon:00:00-Mon:03:00"
+  major_engine_version    = "12"
+  name                    = "boundary"
+  password                = random_password.postgresql.result
+  port                    = 5432
+  storage_encrypted       = false
+  subnet_ids              = var.vpc_zone_identifier
+  tags                    = var.tags
+  username                = "boundary"
+  vpc_security_group_ids  = [aws_security_group.postgresql.id]
+}
+
+module "controllers" {
+  source = "../boundary"
+
+  auto_scaling_group_name = "boundary-controller"
+  boundary_release        = var.boundary_release
+  desired_capacity        = var.desired_capacity
+  iam_instance_profile    = aws_iam_instance_profile.boundary.name
+  image_id                = var.image_id
+  instance_type           = var.instance_type
+  key_name                = var.key_name
+  max_size                = var.max_size
+  min_size                = var.min_size
+
+  # Initialize the DB before starting the service
+  runcmd = [
+    "boundary database init -config /etc/boundary/configuration.hcl"
+  ]
+
+  security_groups     = [aws_security_group.controller.id]
+  tags                = var.tags
+  target_group_arns   = module.alb.target_group_arns
+  vpc_zone_identifier = var.vpc_zone_identifier
+
+  write_files = [
+    {
+      content     = base64encode(local.configuration)
+      encoding    = "b64"
+      owner       = "root:root"
+      path        = "/etc/boundary/configuration.hcl"
+      permissions = "0644"
+    }
+  ]
+}
+
+# https://www.boundaryproject.io/docs/configuration/kms/awskms#authentication
+data "aws_iam_policy_document" "kms" {
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt"
+    ]
+
+    effect = "Allow"
+
+    resources = [aws_kms_key.boundary.arn]
+  }
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    effect = "Allow"
+
+    principals {
+      identifiers = ["ec2.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_policy" "kms" {
+  name   = "BoundaryServiceRolePolicy"
+  policy = data.aws_iam_policy_document.kms.json
+}
+
+resource "aws_iam_role" "boundary" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  name               = "ServiceRoleForBoundary"
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "kms" {
+  policy_arn = aws_iam_policy.kms.arn
+  role       = aws_iam_role.boundary.name
+}
+
+resource "aws_iam_instance_profile" "boundary" {
+  role = aws_iam_role.boundary.name
+}
+
+# The root AWS KMS key used by controllers and workers
+resource "aws_kms_key" "boundary" {
+  deletion_window_in_days = 7
+  key_usage               = "ENCRYPT_DECRYPT"
+  tags                    = var.tags
+}

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -92,7 +92,7 @@ module "alb" {
   load_balancer_type = "application"
   name               = "boundary"
   security_groups    = [aws_security_group.alb.id]
-  subnets            = var.subnets
+  subnets            = var.public_subnets
   tags               = var.tags
 
   target_groups = [
@@ -128,7 +128,7 @@ module "postgresql" {
   password                = random_password.postgresql.result
   port                    = 5432
   storage_encrypted       = false
-  subnet_ids              = var.vpc_zone_identifier
+  subnet_ids              = var.private_subnets
   tags                    = var.tags
   username                = "boundary"
   vpc_security_group_ids  = [aws_security_group.postgresql.id]
@@ -155,7 +155,7 @@ module "controllers" {
   security_groups     = [aws_security_group.controller.id]
   tags                = var.tags
   target_group_arns   = module.alb.target_group_arns
-  vpc_zone_identifier = var.vpc_zone_identifier
+  vpc_zone_identifier = var.private_subnets
 
   write_files = [
     {

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -1,0 +1,14 @@
+output "iam_instance_profile" {
+  description = <<EOF
+The name or the Amazon Resource Name (ARN) of the instance profile
+associated with the IAM role for the instance. The instance profile
+contains the IAM role.
+EOF
+
+  value = aws_iam_instance_profile.boundary.name
+}
+
+output "load_balancer_address" {
+  description = "The public DNS name of the load balancer"
+  value       = module.alb.this_lb_dns_name
+}

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -1,14 +1,9 @@
-output "iam_instance_profile" {
-  description = <<EOF
-The name or the Amazon Resource Name (ARN) of the instance profile
-associated with the IAM role for the instance. The instance profile
-contains the IAM role.
-EOF
-
-  value = aws_iam_instance_profile.boundary.name
-}
-
-output "load_balancer_address" {
+output "dns_name" {
   description = "The public DNS name of the load balancer"
   value       = module.alb.this_lb_dns_name
+}
+
+output "kms_key_id" {
+  description = "The unique identifier for the worker-auth key"
+  value       = aws_kms_key.auth.key_id
 }

--- a/modules/controller/templates/configuration.hcl.tpl
+++ b/modules/controller/templates/configuration.hcl.tpl
@@ -8,15 +8,13 @@ controller {
   name = "controller"
 }
 
+%{ for key in keys ~}
 kms "awskms" {
-  kms_key_id = "${kms_key_id}"
-  purpose    = "root"
+  kms_key_id = "${key["key_id"]}"
+  purpose    = "${key["purpose"]}"
 }
 
-kms "awskms" {
-  kms_key_id = "${kms_key_id}"
-  purpose    = "worker-auth"
-}
+%{ endfor ~}
 
 listener "tcp" {
   address     = "0.0.0.0"

--- a/modules/controller/templates/configuration.hcl.tpl
+++ b/modules/controller/templates/configuration.hcl.tpl
@@ -1,0 +1,31 @@
+disable_mlock = true
+
+controller {
+  database {
+    url = "${database_url}"
+  }
+
+  name = "controller"
+}
+
+kms "awskms" {
+  kms_key_id = "${kms_key_id}"
+  purpose    = "root"
+}
+
+kms "awskms" {
+  kms_key_id = "${kms_key_id}"
+  purpose    = "worker-auth"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0"
+  purpose     = "cluster"
+  tls_disable = true
+}
+
+listener "tcp" {
+  address     = "0.0.0.0"
+  purpose     = "api"
+  tls_disable = true
+}

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -1,0 +1,89 @@
+variable "boundary_release" {
+  default     = "0.1.0"
+  description = ""
+  type        = string
+}
+
+variable "desired_capacity" {
+  default = 3
+
+  description = <<EOF
+The desired capacity is the initial capacity of the Auto Scaling group
+at the time of its creation and the capacity it attempts to maintain.
+EOF
+
+  type = number
+}
+
+variable "iam_instance_profile" {
+  default = ""
+
+  description = <<EOF
+The name or the Amazon Resource Name (ARN) of the instance profile
+associated with the IAM role for the instance. The instance profile
+contains the IAM role.
+EOF
+
+  type = string
+}
+
+variable "image_id" {
+  description = <<EOF
+The ID of the Amazon Machine Image (AMI) that was assigned during registration
+EOF
+
+  type = string
+}
+
+variable "instance_type" {
+  default     = "t3.small"
+  description = "Specifies the instance type of the EC2 instance"
+  type        = string
+}
+
+variable "key_name" {
+  default     = ""
+  description = "The name of the key pair"
+  type        = string
+}
+
+variable "max_size" {
+  default     = 3
+  description = "The maximum size of the group"
+  type        = number
+}
+
+variable "min_size" {
+  default     = 3
+  description = "The minimum size of the group"
+  type        = number
+}
+
+variable "subnets" {
+  description = "The IDs of the public subnets"
+  type        = list(string)
+}
+
+variable "tags" {
+  default = {}
+
+  description = <<EOF
+One or more tags. You can tag your Auto Scaling group and propagate the tags to
+the Amazon EC2 instances it launches.
+EOF
+
+  type = map(string)
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC"
+  type        = string
+}
+
+variable "vpc_zone_identifier" {
+  description = <<EOF
+A comma-separated list of subnet IDs for your virtual private cloud
+EOF
+
+  type = list(string)
+}

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -1,6 +1,6 @@
 variable "boundary_release" {
   default     = "0.1.0"
-  description = ""
+  description = "The version of Boundary to install"
   type        = string
 }
 
@@ -59,8 +59,13 @@ variable "min_size" {
   type        = number
 }
 
-variable "subnets" {
-  description = "The IDs of the public subnets"
+variable "private_subnets" {
+  description = "List of private subnets"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "List of public subnets"
   type        = list(string)
 }
 
@@ -78,12 +83,4 @@ EOF
 variable "vpc_id" {
   description = "The ID of the VPC"
   type        = string
-}
-
-variable "vpc_zone_identifier" {
-  description = <<EOF
-A comma-separated list of subnet IDs for your virtual private cloud
-EOF
-
-  type = list(string)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
-output "load_balancer_address" {
-  value = module.controllers.load_balancer_address
+output "dns_name" {
+  description = "The public DNS name of the controller load balancer"
+  value       = module.controllers.dns_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "load_balancer_address" {
+  value = module.controllers.load_balancer_address
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,83 @@
+variable "boundary_release" {
+  default     = "0.1.0"
+  description = ""
+  type        = string
+}
+
+variable "cidr_block" {
+  default     = "10.0.0.0/16"
+  description = ""
+  type        = string
+}
+
+variable "controller_desired_capacity" {
+  default     = 3
+  description = ""
+  type        = number
+}
+
+variable "controller_instance_type" {
+  default     = "t3.small"
+  description = ""
+  type        = string
+}
+
+variable "controller_max_size" {
+  default     = 3
+  description = ""
+  type        = number
+}
+
+variable "controller_min_size" {
+  default     = 3
+  description = ""
+  type        = number
+}
+
+variable "subnets" {
+  default     = []
+  description = ""
+  type        = list(string)
+}
+
+variable "tags" {
+  default     = {}
+  description = ""
+  type        = map(string)
+}
+
+variable "vpc_id" {
+  default     = ""
+  description = ""
+  type        = string
+}
+
+variable "vpc_zone_identifier" {
+  default     = []
+  description = ""
+  type        = list(string)
+}
+
+variable "worker_desired_capacity" {
+  default     = 3
+  description = ""
+  type        = number
+}
+
+variable "worker_instance_type" {
+  default     = "t3.small"
+  description = ""
+  type        = string
+}
+
+variable "worker_max_size" {
+  default     = 3
+  description = ""
+  type        = number
+}
+
+variable "worker_min_size" {
+  default     = 3
+  description = ""
+  type        = number
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,83 +1,83 @@
 variable "boundary_release" {
   default     = "0.1.0"
-  description = ""
+  description = "The version of Boundary to install"
   type        = string
 }
 
 variable "cidr_block" {
   default     = "10.0.0.0/16"
-  description = ""
+  description = "The IPv4 network range for the VPC, in CIDR notation. For example, 10.0.0.0/16."
   type        = string
 }
 
 variable "controller_desired_capacity" {
   default     = 3
-  description = ""
+  description = "The capacity the controller Auto Scaling group attempts to maintain"
   type        = number
 }
 
 variable "controller_instance_type" {
   default     = "t3.small"
-  description = ""
+  description = "Specifies the instance type of the controller EC2 instance"
   type        = string
 }
 
 variable "controller_max_size" {
   default     = 3
-  description = ""
+  description = "The maximum size of the controller group"
   type        = number
 }
 
 variable "controller_min_size" {
   default     = 3
-  description = ""
+  description = "The minimum size of the controller group"
   type        = number
 }
 
-variable "subnets" {
+variable "private_subnets" {
   default     = []
-  description = ""
+  description = "List of private subnets"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  default     = []
+  description = "List of public subnets"
   type        = list(string)
 }
 
 variable "tags" {
   default     = {}
-  description = ""
+  description = "One or more tags"
   type        = map(string)
 }
 
 variable "vpc_id" {
   default     = ""
-  description = ""
+  description = "The ID of the VPC"
   type        = string
-}
-
-variable "vpc_zone_identifier" {
-  default     = []
-  description = ""
-  type        = list(string)
 }
 
 variable "worker_desired_capacity" {
   default     = 3
-  description = ""
+  description = "The capacity the worker Auto Scaling group attempts to maintain"
   type        = number
 }
 
 variable "worker_instance_type" {
   default     = "t3.small"
-  description = ""
+  description = "Specifies the instance type of the worker EC2 instance"
   type        = string
 }
 
 variable "worker_max_size" {
   default     = 3
-  description = ""
+  description = "The maximum size of the worker group"
   type        = number
 }
 
 variable "worker_min_size" {
   default     = 3
-  description = ""
+  description = "The minimum size of the worker group"
   type        = number
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
### Overview

This pull request introduces two modules, `boundary` and `controller`, respectively for creating the necessary Boundary [controller](https://www.boundaryproject.io/docs/installing/high-availability) resources.

### Description

The `boundary` module is responsible for creating the [AWS Auto Scaling](https://aws.amazon.com/autoscaling/) group and launch configuration used by the ASG.

The module uses [cloud-init](https://cloudinit.readthedocs.io/en/latest/) to provision the EC2 instances associated with the auto scaling group. Each instance in the group downloads the [Boundary](https://cloudinit.readthedocs.io/en/latest/) artifact to `/usr/local/bin` and writes the [systemd unit file](https://www.boundaryproject.io/docs/installing/systemd) to `/etc/systemd/system/boundary.service`.

The Boundary service is started using `systemctl` (`systemctl start boundary`).

It is worth mentioning that the `boundary` module contains two input variables, `runcmd` and `write_files`. These input variables allow the `controller` and `worker` modules to run any specific commands *after* the Boundary artifact is installed, but *before* starting the Boundary service.

For example, the Boundary controller requires [initializing](https://www.boundaryproject.io/docs/installing/systemd#systemd-all-in-one-installation-script) the PostgreSQL database *before* starting the Boundary agent:

```
$ boundary database init -config /etc/boundary/configuration.hcl
```

Similarly, the `write_files` input variable allow the `controller` and `worker` modules to write their configuration files to `/etc/boundary/configuration.hcl`.

The `controller` module creates an PostgreSQL database using [AWS RDS](https://aws.amazon.com/rds/) and the [AWS KMS](https://aws.amazon.com/kms/) key [required by Boundary](https://www.boundaryproject.io/docs/configuration/kms/awskms).

## Life Cycle

This module is designed to make the worker nodes **dependent** on the controller nodes since the worker nodes [gossip](https://www.boundaryproject.io/docs/configuration/worker#complete-configuration-example) with the controller nodes on `:9202` and the worker and controller nodes share the same KMS `worker-auth` key.

While the `worker` module is not yet developed, it is assumed that the `controller` module shall export output variables to be used as input variables to the `worker` module. This workflow creates an implicit dependency between the two modules and forces the worker nodes to wait for the controller nodes to become available.