### PR TITLE
feat: add worker module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,86 @@
+## Contents
+
+- [Usage](#usage)
+- [Life cycle](#life-cycle)
+- [Contributing](#contributing)
+- [Inputs](#inputs)
+- [Outputs](#outputs)
+- [License](#license)
+
+**Note:** Like HashiCorp Boundary, this module is relatively new and may contain some issues. If you do experience an issue, please create a [new issue](https://github.com/jasonwalsh/terraform-aws-boundary/issues) in the repository. Pull requests are also welcome!
+
+## Usage
+
+This module uses Terraform to install [HashiCorp Boundary](https://www.boundaryproject.io/) in an Amazon Web Services (AWS) account.
+
+This module uses the [official documentation](https://www.boundaryproject.io/docs/installing/high-availability) to install a highly available service.
+
+![high-availability-service](https://www.boundaryproject.io/img/production.png)
+
+This module creates the following resources:
+
+- A virtual private cloud with all associated networking resources (e.g., public and private subnets, route tables, internet gateways, NAT gateways, etc)
+- A PostgreSQL RDS instance used by the [Boundary controllers](https://www.boundaryproject.io/docs/installing/postgres)
+- Two [AWS KMS](https://www.boundaryproject.io/docs/configuration/kms/awskms) keys, one for `root` and the other for `worker-auth`
+- An application load balancer (ALB) that serves as a gateway to the Boundary UI/API
+- Two auto scaling groups, one for controller instances and the other for worker instances
+
+For more information on Boundary, please visit the [official documentation](https://www.boundaryproject.io/docs) or the [tutorials](https://learn.hashicorp.com/boundary) on HashiCorp Learn.
+
+To use this module, the following environment variables are required:
+
+| Name |
+|------|
+| `AWS_ACCESS_KEY_ID` |
+| `AWS_SECRET_ACCESS_KEY` |
+| `AWS_DEFAULT_REGION` |
+
+After exporting the environment variables, simply run the following command:
+
+```
+$ terraform apply
+```
+
+## Life cycle
+
+This module creates the controller instances *before* the worker instances. This implicit dependency ensures that the controller and worker instances share the same `worker-auth` KMS key.
+
+The [controller](modules/controller) module also initializes the PostgreSQL database using the following command:
+
+```
+$ boundary database init -config /etc/boundary/configuration.hcl
+```
+
+After initializing the database, Boundary outputs information required to authenticate as defined [here](https://learn.hashicorp.com/tutorials/boundary/getting-started-dev?in=boundary/getting-started). Notably, the Auth Method ID, Login Name, and Password are generated.
+
+Since initializing the database is a one-time operation, this module writes the output of the command to an S3 bucket so that the user always has access to this information.
+
+In order to retrieve the information, you can invoke the following command:
+
+```
+$ $(terraform output s3command)
+```
+
+**Note:** The `$` before the `(` is required to run this command.
+
+The result of running the command displays the contents of the [`cloud-init-output.log`](https://cloudinit.readthedocs.io/en/latest/topics/logging.html), which contains the output of the `boundary database init` command.
+
+After you run this command, you can visit the Boundary UI using the `dns_name` output.
+
+To authenticate to Boundary, you can reference [this](https://learn.hashicorp.com/tutorials/boundary/getting-started-connect?in=boundary/getting-started) guide.
+
+**Note:** If you attempt to run the `authenticate` command and are met with this error `Error trying to perform authentication: dial tcp 127.0.0.1:9200: connect: connection refused`, you can export the `BOUNDARY_ADDR` environment variable to the value of the DNS name of the ALB. For example:
+
+```
+export BOUNDARY_ADDR="http://$(terraform output dns_name)"
+```
+
+## Contributing
+
+As mentioned in the beginning of the README, this module is relatively new and may have issues. If you do discover an issue, please create a [new issue](https://github.com/jasonwalsh/terraform-aws-boundary/issues) or a [pull request](https://github.com/jasonwalsh/terraform-aws-boundary/pulls).
+
+As always, thanks for using this module!
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -39,3 +122,7 @@
 | s3command | The S3 cp command used to display the contents of the cloud-init-output.log |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## License
+
+[MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 | Name | Version |
 |------|---------|
 | aws | n/a |
+| random | n/a |
 
 ## Inputs
 
@@ -35,5 +36,6 @@
 | Name | Description |
 |------|-------------|
 | dns\_name | The public DNS name of the controller load balancer |
+| s3command | The S3 cp command used to display the contents of the cloud-init-output.log |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/boundary/README.md
+++ b/modules/boundary/README.md
@@ -1,0 +1,37 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No provider.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| auto\_scaling\_group\_name | The name of the Auto Scaling group | `string` | n/a | yes |
+| boundary\_release | The version of Boundary to install | `string` | n/a | yes |
+| bucket\_name | The name of the bucket to upload the contents of the<br>cloud-init-output.log file | `string` | n/a | yes |
+| desired\_capacity | The desired capacity is the initial capacity of the Auto Scaling group<br>at the time of its creation and the capacity it attempts to maintain. | `number` | `0` | no |
+| iam\_instance\_profile | The name or the Amazon Resource Name (ARN) of the instance profile associated<br>with the IAM role for the instance | `string` | `""` | no |
+| image\_id | The ID of the Amazon Machine Image (AMI) that was assigned during registration | `string` | n/a | yes |
+| instance\_type | Specifies the instance type of the EC2 instance | `string` | n/a | yes |
+| key\_name | The name of the key pair | `string` | `""` | no |
+| max\_size | The maximum size of the group | `number` | n/a | yes |
+| min\_size | The minimum size of the group | `number` | n/a | yes |
+| runcmd | Run arbitrary commands at a rc.local like level with output to the<br>console. Each item can be either a list or a string. | `list(string)` | `[]` | no |
+| security\_groups | A list that contains the security groups to assign to the instances in the Auto<br>Scaling group | `list(string)` | `[]` | no |
+| tags | One or more tags. You can tag your Auto Scaling group and propagate the tags to<br>the Amazon EC2 instances it launches. | `map(string)` | `{}` | no |
+| target\_group\_arns | The Amazon Resource Names (ARN) of the target groups to associate with the Auto<br>Scaling group | `list(string)` | `[]` | no |
+| vpc\_zone\_identifier | A comma-separated list of subnet IDs for your virtual private cloud | `list(string)` | n/a | yes |
+| write\_files | Write out arbitrary content to files, optionally setting permissions | <pre>list(object({<br>    content     = string<br>    owner       = string<br>    path        = string<br>    permissions = string<br>  }))</pre> | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| auto\_scaling\_group\_name | The name of the controller Auto Scaling group |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/boundary/main.tf
+++ b/modules/boundary/main.tf
@@ -13,13 +13,17 @@ locals {
 
     runcmd = concat(
       [
+        "curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip",
+        "unzip awscliv2.zip",
+        "./aws/install",
         "wget -O boundary.zip ${local.download_url}",
         "unzip boundary.zip -d /usr/local/bin"
       ],
       var.runcmd,
       [
         "systemctl enable boundary",
-        "systemctl start boundary"
+        "systemctl start boundary",
+        "grep 'Initial auth information' /var/log/cloud-init-output.log && aws s3 cp /var/log/cloud-init-output.log s3://${var.bucket_name}/{{v1.local_hostname}}/cloud-init-output.log || true"
       ]
     )
 
@@ -56,6 +60,7 @@ module "autoscaling" {
   target_group_arns            = var.target_group_arns
 
   user_data = <<EOF
+## template: jinja
 #cloud-config
 ${yamlencode(local.user_data)}
 EOF

--- a/modules/boundary/outputs.tf
+++ b/modules/boundary/outputs.tf
@@ -1,3 +1,4 @@
 output "auto_scaling_group_name" {
-  value = module.autoscaling.this_autoscaling_group_name
+  description = "The name of the controller Auto Scaling group"
+  value       = module.autoscaling.this_autoscaling_group_name
 }

--- a/modules/boundary/outputs.tf
+++ b/modules/boundary/outputs.tf
@@ -1,0 +1,3 @@
+output "auto_scaling_group_name" {
+  value = module.autoscaling.this_autoscaling_group_name
+}

--- a/modules/boundary/variables.tf
+++ b/modules/boundary/variables.tf
@@ -8,6 +8,11 @@ variable "boundary_release" {
   type        = string
 }
 
+variable "bucket_name" {
+  description = ""
+  type        = string
+}
+
 variable "desired_capacity" {
   default = 0
 
@@ -116,7 +121,6 @@ variable "write_files" {
 
   type = list(object({
     content     = string
-    encoding    = string
     owner       = string
     path        = string
     permissions = string

--- a/modules/boundary/variables.tf
+++ b/modules/boundary/variables.tf
@@ -9,8 +9,12 @@ variable "boundary_release" {
 }
 
 variable "bucket_name" {
-  description = ""
-  type        = string
+  description = <<EOF
+The name of the bucket to upload the contents of the
+cloud-init-output.log file
+EOF
+
+  type = string
 }
 
 variable "desired_capacity" {

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -1,0 +1,39 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| random | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| boundary\_release | The version of Boundary to install | `string` | `"0.1.0"` | no |
+| bucket\_name | The name of the bucket to upload the contents of the<br>cloud-init-output.log file | `string` | n/a | yes |
+| desired\_capacity | The desired capacity is the initial capacity of the Auto Scaling group<br>at the time of its creation and the capacity it attempts to maintain. | `number` | `3` | no |
+| image\_id | The ID of the Amazon Machine Image (AMI) that was assigned during registration | `string` | n/a | yes |
+| instance\_type | Specifies the instance type of the EC2 instance | `string` | `"t3.small"` | no |
+| key\_name | The name of the key pair | `string` | `""` | no |
+| max\_size | The maximum size of the group | `number` | `3` | no |
+| min\_size | The minimum size of the group | `number` | `3` | no |
+| private\_subnets | List of private subnets | `list(string)` | n/a | yes |
+| public\_subnets | List of public subnets | `list(string)` | n/a | yes |
+| tags | One or more tags. You can tag your Auto Scaling group and propagate the tags to<br>the Amazon EC2 instances it launches. | `map(string)` | `{}` | no |
+| vpc\_id | The ID of the VPC | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| dns\_name | The public DNS name of the load balancer |
+| ip\_addresses | One or more private IPv4 addresses associated with the controllers |
+| kms\_key\_id | The unique identifier for the worker-auth key |
+| security\_group\_id | The ID of the controller security group |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -4,7 +4,8 @@ output "dns_name" {
 }
 
 output "ip_addresses" {
-  value = data.aws_instances.controllers.private_ips
+  description = "One or more private IPv4 addresses associated with the controllers"
+  value       = data.aws_instances.controllers.private_ips
 }
 
 output "kms_key_id" {
@@ -13,5 +14,6 @@ output "kms_key_id" {
 }
 
 output "security_group_id" {
-  value = aws_security_group.controller.id
+  description = "The ID of the controller security group"
+  value       = aws_security_group.controller.id
 }

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -3,7 +3,15 @@ output "dns_name" {
   value       = module.alb.this_lb_dns_name
 }
 
+output "ip_addresses" {
+  value = data.aws_instances.controllers.private_ips
+}
+
 output "kms_key_id" {
   description = "The unique identifier for the worker-auth key"
   value       = aws_kms_key.auth.key_id
+}
+
+output "security_group_id" {
+  value = aws_security_group.controller.id
 }

--- a/modules/controller/templates/configuration.hcl.tpl
+++ b/modules/controller/templates/configuration.hcl.tpl
@@ -1,5 +1,3 @@
-disable_mlock = true
-
 controller {
   database {
     url = "${database_url}"
@@ -7,6 +5,8 @@ controller {
 
   name = "controller"
 }
+
+disable_mlock = true
 
 %{ for key in keys ~}
 kms "awskms" {
@@ -17,13 +17,13 @@ kms "awskms" {
 %{ endfor ~}
 
 listener "tcp" {
-  address     = "0.0.0.0"
+  address     = "{{ds.meta_data.local_ipv4}}:9201"
   purpose     = "cluster"
   tls_disable = true
 }
 
 listener "tcp" {
-  address     = "0.0.0.0"
+  address     = "{{ds.meta_data.local_ipv4}}:9200"
   purpose     = "api"
   tls_disable = true
 }

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -5,8 +5,12 @@ variable "boundary_release" {
 }
 
 variable "bucket_name" {
-  description = ""
-  type        = string
+  description = <<EOF
+The name of the bucket to upload the contents of the
+cloud-init-output.log file
+EOF
+
+  type = string
 }
 
 variable "desired_capacity" {

--- a/modules/worker/README.md
+++ b/modules/worker/README.md
@@ -1,0 +1,35 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| boundary\_release | The version of Boundary to install | `string` | `"0.1.0"` | no |
+| bucket\_name | The name of the bucket to upload the contents of the<br>cloud-init-output.log file | `string` | n/a | yes |
+| desired\_capacity | The desired capacity is the initial capacity of the Auto Scaling group<br>at the time of its creation and the capacity it attempts to maintain. | `number` | `3` | no |
+| image\_id | The ID of the Amazon Machine Image (AMI) that was assigned during registration | `string` | n/a | yes |
+| instance\_type | Specifies the instance type of the EC2 instance | `string` | `"t3.small"` | no |
+| ip\_addresses | One or more private IPv4 addresses associated with the controllers | `list(string)` | `[]` | no |
+| key\_name | The name of the key pair | `string` | `""` | no |
+| kms\_key\_id | The unique identifier for the worker-auth key | `string` | n/a | yes |
+| max\_size | The maximum size of the group | `number` | `3` | no |
+| min\_size | The minimum size of the group | `number` | `3` | no |
+| public\_subnets | List of public subnets | `list(string)` | n/a | yes |
+| security\_group\_id | The ID of the controller security group | `string` | n/a | yes |
+| tags | One or more tags. You can tag your Auto Scaling group and propagate the tags to<br>the Amazon EC2 instances it launches. | `map(string)` | `{}` | no |
+| vpc\_id | The ID of the VPC | `string` | n/a | yes |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/worker/main.tf
+++ b/modules/worker/main.tf
@@ -1,0 +1,137 @@
+locals {
+  configuration = templatefile(
+    "${path.module}/templates/configuration.hcl.tpl",
+    {
+      controllers = jsonencode(var.ip_addresses)
+
+      keys = [
+        {
+          key_id  = data.aws_kms_key.auth.id
+          purpose = "worker-auth"
+        }
+      ]
+    }
+  )
+}
+
+data "aws_kms_key" "auth" {
+  key_id = var.kms_key_id
+}
+
+data "aws_security_group" "controller" {
+  id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "controller" {
+  from_port                = 9201
+  protocol                 = "TCP"
+  security_group_id        = data.aws_security_group.controller.id
+  source_security_group_id = aws_security_group.worker.id
+  to_port                  = 9201
+  type                     = "ingress"
+}
+
+resource "aws_security_group" "worker" {
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 22
+    protocol    = "TCP"
+    to_port     = 22
+  }
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 9202
+    protocol    = "TCP"
+    to_port     = 9202
+  }
+
+  name   = "Boundary worker"
+  tags   = var.tags
+  vpc_id = var.vpc_id
+}
+
+module "workers" {
+  source = "../boundary"
+
+  auto_scaling_group_name = "boundary-worker"
+  boundary_release        = var.boundary_release
+  bucket_name             = var.bucket_name
+  desired_capacity        = var.desired_capacity
+  iam_instance_profile    = aws_iam_instance_profile.worker.name
+  image_id                = var.image_id
+  instance_type           = var.instance_type
+  key_name                = var.key_name
+  max_size                = var.max_size
+  min_size                = var.min_size
+  security_groups         = [aws_security_group.worker.id]
+  tags                    = var.tags
+  vpc_zone_identifier     = var.public_subnets
+
+  write_files = [
+    {
+      content     = local.configuration
+      owner       = "root:root"
+      path        = "/etc/boundary/configuration.hcl"
+      permissions = "0644"
+    }
+  ]
+}
+
+# https://www.boundaryproject.io/docs/configuration/kms/awskms#authentication
+#
+# Allows the workers to invoke the Decrypt, DescribeKey, and Encrypt
+# routines for the worker-auth key.
+data "aws_iam_policy_document" "kms" {
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt"
+    ]
+
+    effect = "Allow"
+
+    resources = [data.aws_kms_key.auth.arn]
+  }
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    effect = "Allow"
+
+    principals {
+      identifiers = ["ec2.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_policy" "kms" {
+  name   = "BoundaryWorkerServiceRolePolicy"
+  policy = data.aws_iam_policy_document.kms.json
+}
+
+resource "aws_iam_role" "worker" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  name               = "ServiceRoleForBoundaryWorker"
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "kms" {
+  policy_arn = aws_iam_policy.kms.arn
+  role       = aws_iam_role.worker.name
+}
+
+resource "aws_iam_instance_profile" "worker" {
+  role = aws_iam_role.worker.name
+}

--- a/modules/worker/templates/configuration.hcl.tpl
+++ b/modules/worker/templates/configuration.hcl.tpl
@@ -1,0 +1,21 @@
+disable_mlock = true
+
+%{ for key in keys ~}
+kms "awskms" {
+  kms_key_id = "${key["key_id"]}"
+  purpose    = "${key["purpose"]}"
+}
+
+%{ endfor ~}
+
+listener "tcp" {
+  address     = "{{ds.meta_data.local_ipv4}}:9202"
+  purpose     = "proxy"
+  tls_disable = true
+}
+
+worker {
+  controllers = ${controllers}
+  name        = "worker-{{v1.local_hostname}}"
+  public_addr = "{{ds.meta_data.public_ipv4}}"
+}

--- a/modules/worker/variables.tf
+++ b/modules/worker/variables.tf
@@ -5,8 +5,12 @@ variable "boundary_release" {
 }
 
 variable "bucket_name" {
-  description = ""
-  type        = string
+  description = <<EOF
+The name of the bucket to upload the contents of the
+cloud-init-output.log file
+EOF
+
+  type = string
 }
 
 variable "desired_capacity" {
@@ -36,7 +40,7 @@ variable "instance_type" {
 
 variable "ip_addresses" {
   default     = []
-  description = ""
+  description = "One or more private IPv4 addresses associated with the controllers"
   type        = list(string)
 }
 
@@ -47,7 +51,7 @@ variable "key_name" {
 }
 
 variable "kms_key_id" {
-  description = ""
+  description = "The unique identifier for the worker-auth key"
   type        = string
 }
 
@@ -69,7 +73,7 @@ variable "public_subnets" {
 }
 
 variable "security_group_id" {
-  description = ""
+  description = "The ID of the controller security group"
   type        = string
 }
 

--- a/modules/worker/variables.tf
+++ b/modules/worker/variables.tf
@@ -34,9 +34,20 @@ variable "instance_type" {
   type        = string
 }
 
+variable "ip_addresses" {
+  default     = []
+  description = ""
+  type        = list(string)
+}
+
 variable "key_name" {
   default     = ""
   description = "The name of the key pair"
+  type        = string
+}
+
+variable "kms_key_id" {
+  description = ""
   type        = string
 }
 
@@ -52,14 +63,14 @@ variable "min_size" {
   type        = number
 }
 
-variable "private_subnets" {
-  description = "List of private subnets"
-  type        = list(string)
-}
-
 variable "public_subnets" {
   description = "List of public subnets"
   type        = list(string)
+}
+
+variable "security_group_id" {
+  description = ""
+  type        = string
 }
 
 variable "tags" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "dns_name" {
 }
 
 output "s3command" {
-  description = ""
+  description = "The S3 cp command used to display the contents of the cloud-init-output.log"
 
   value = format(
     "aws s3 cp s3://%s/%s -",

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,13 @@ output "dns_name" {
   description = "The public DNS name of the controller load balancer"
   value       = module.controllers.dns_name
 }
+
+output "s3command" {
+  description = ""
+
+  value = format(
+    "aws s3 cp s3://%s/%s -",
+    aws_s3_bucket.boundary.id,
+    data.aws_s3_bucket_objects.cloudinit.keys[0]
+  )
+}


### PR DESCRIPTION
The worker module is responsible for creating an Auto Scaling Group of
Boundary workers.

The `worker` module is dependent on the `controller` module. In order to
allow the workers to connect to the controller hosts, the `worker`
module requires the `ip_addresses` variable.

The value of the `ip_addresses` variable is a list of strings, where
each value is the private IP address of each controller EC2 instance
instance in the Auto Scaling Group.

When the `controller` module initializes the PostgreSQL database, it
writes the credentials for the `admin` user to stdout.

The `boundary` module will grep the contents of the
`/var/log/cloud-init-output.log` file and if it contains the text
"Initial auth information", then it writes the contents to an S3 bucket.

Writing the contents to an S3 bucket ensures that the admin credentials
are always available to the user, even if the Auto Scaling Group is
re-created.