### PR TITLE
feat: support bastion host creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ As always, thanks for using this module!
 | controller\_instance\_type | Specifies the instance type of the controller EC2 instance | `string` | `"t3.small"` | no |
 | controller\_max\_size | The maximum size of the controller group | `number` | `3` | no |
 | controller\_min\_size | The minimum size of the controller group | `number` | `3` | no |
+| key\_name | The name of the key pair | `string` | `""` | no |
 | private\_subnets | List of private subnets | `list(string)` | `[]` | no |
 | public\_subnets | List of public subnets | `list(string)` | `[]` | no |
 | tags | One or more tags | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ module "controllers" {
   desired_capacity = var.controller_desired_capacity
   image_id         = local.image_id
   instance_type    = var.controller_instance_type
+  key_name         = var.key_name
   max_size         = var.controller_max_size
   min_size         = var.controller_min_size
   private_subnets  = local.private_subnets
@@ -63,19 +64,21 @@ module "controllers" {
 module "workers" {
   source = "./modules/worker"
 
-  boundary_release  = var.boundary_release
-  bucket_name       = aws_s3_bucket.boundary.id
-  desired_capacity  = var.worker_desired_capacity
-  image_id          = local.image_id
-  instance_type     = var.worker_instance_type
-  ip_addresses      = module.controllers.ip_addresses
-  kms_key_id        = module.controllers.kms_key_id
-  max_size          = var.worker_max_size
-  min_size          = var.worker_min_size
-  public_subnets    = local.public_subnets
-  security_group_id = module.controllers.security_group_id
-  tags              = local.tags
-  vpc_id            = local.vpc_id
+  bastion_security_group = module.controllers.bastion_security_group
+  boundary_release       = var.boundary_release
+  bucket_name            = aws_s3_bucket.boundary.id
+  desired_capacity       = var.worker_desired_capacity
+  image_id               = local.image_id
+  instance_type          = var.worker_instance_type
+  ip_addresses           = module.controllers.ip_addresses
+  key_name               = var.key_name
+  kms_key_id             = module.controllers.kms_key_id
+  max_size               = var.worker_max_size
+  min_size               = var.worker_min_size
+  public_subnets         = local.public_subnets
+  security_group_id      = module.controllers.security_group_id
+  tags                   = local.tags
+  vpc_id                 = local.vpc_id
 }
 
 module "vpc" {

--- a/modules/boundary/README.md
+++ b/modules/boundary/README.md
@@ -11,7 +11,9 @@ No provider.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| after\_start | Run arbitrary commands after starting the Boundary service | `list(string)` | `[]` | no |
 | auto\_scaling\_group\_name | The name of the Auto Scaling group | `string` | n/a | yes |
+| before\_start | Run arbitrary commands before starting the Boundary service | `list(string)` | `[]` | no |
 | boundary\_release | The version of Boundary to install | `string` | n/a | yes |
 | bucket\_name | The name of the bucket to upload the contents of the<br>cloud-init-output.log file | `string` | n/a | yes |
 | desired\_capacity | The desired capacity is the initial capacity of the Auto Scaling group<br>at the time of its creation and the capacity it attempts to maintain. | `number` | `0` | no |
@@ -21,7 +23,6 @@ No provider.
 | key\_name | The name of the key pair | `string` | `""` | no |
 | max\_size | The maximum size of the group | `number` | n/a | yes |
 | min\_size | The minimum size of the group | `number` | n/a | yes |
-| runcmd | Run arbitrary commands at a rc.local like level with output to the<br>console. Each item can be either a list or a string. | `list(string)` | `[]` | no |
 | security\_groups | A list that contains the security groups to assign to the instances in the Auto<br>Scaling group | `list(string)` | `[]` | no |
 | tags | One or more tags. You can tag your Auto Scaling group and propagate the tags to<br>the Amazon EC2 instances it launches. | `map(string)` | `{}` | no |
 | target\_group\_arns | The Amazon Resource Names (ARN) of the target groups to associate with the Auto<br>Scaling group | `list(string)` | `[]` | no |

--- a/modules/boundary/main.tf
+++ b/modules/boundary/main.tf
@@ -13,18 +13,15 @@ locals {
 
     runcmd = concat(
       [
-        "curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip",
-        "unzip awscliv2.zip",
-        "./aws/install",
         "wget -O boundary.zip ${local.download_url}",
         "unzip boundary.zip -d /usr/local/bin"
       ],
-      var.runcmd,
+      var.before_start,
       [
         "systemctl enable boundary",
         "systemctl start boundary",
-        "grep 'Initial auth information' /var/log/cloud-init-output.log && aws s3 cp /var/log/cloud-init-output.log s3://${var.bucket_name}/{{v1.local_hostname}}/cloud-init-output.log || true"
-      ]
+      ],
+      var.after_start
     )
 
     write_files = concat(

--- a/modules/boundary/variables.tf
+++ b/modules/boundary/variables.tf
@@ -1,6 +1,18 @@
+variable "after_start" {
+  default     = []
+  description = "Run arbitrary commands after starting the Boundary service"
+  type        = list(string)
+}
+
 variable "auto_scaling_group_name" {
   description = "The name of the Auto Scaling group"
   type        = string
+}
+
+variable "before_start" {
+  default     = []
+  description = "Run arbitrary commands before starting the Boundary service"
+  type        = list(string)
 }
 
 variable "boundary_release" {
@@ -65,17 +77,6 @@ variable "max_size" {
 variable "min_size" {
   description = "The minimum size of the group"
   type        = number
-}
-
-variable "runcmd" {
-  default = []
-
-  description = <<EOF
-Run arbitrary commands at a rc.local like level with output to the
-console. Each item can be either a list or a string.
-EOF
-
-  type = list(string)
 }
 
 variable "security_groups" {

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -31,6 +31,7 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
+| bastion\_security\_group | The ID of the bastion security group |
 | dns\_name | The public DNS name of the load balancer |
 | ip\_addresses | One or more private IPv4 addresses associated with the controllers |
 | kms\_key\_id | The unique identifier for the worker-auth key |

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -1,3 +1,8 @@
+output "bastion_security_group" {
+  description = "The ID of the bastion security group"
+  value       = join("", aws_security_group.bastion[*].id)
+}
+
 output "dns_name" {
   description = "The public DNS name of the load balancer"
   value       = module.alb.this_lb_dns_name

--- a/modules/worker/README.md
+++ b/modules/worker/README.md
@@ -13,6 +13,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| bastion\_security\_group | The ID of the bastion security group | `string` | `""` | no |
 | boundary\_release | The version of Boundary to install | `string` | `"0.1.0"` | no |
 | bucket\_name | The name of the bucket to upload the contents of the<br>cloud-init-output.log file | `string` | n/a | yes |
 | desired\_capacity | The desired capacity is the initial capacity of the Auto Scaling group<br>at the time of its creation and the capacity it attempts to maintain. | `number` | `3` | no |

--- a/modules/worker/main.tf
+++ b/modules/worker/main.tf
@@ -47,6 +47,17 @@ resource "aws_security_group" "worker" {
     to_port     = 9202
   }
 
+  dynamic "ingress" {
+    for_each = var.key_name != "" ? [22] : []
+
+    content {
+      from_port       = 22
+      protocol        = "TCP"
+      security_groups = [var.bastion_security_group]
+      to_port         = 22
+    }
+  }
+
   name   = "Boundary worker"
   tags   = var.tags
   vpc_id = var.vpc_id
@@ -55,7 +66,7 @@ resource "aws_security_group" "worker" {
 module "workers" {
   source = "../boundary"
 
-  auto_scaling_group_name = "boundary-worker"
+  auto_scaling_group_name = "Boundary Worker"
   boundary_release        = var.boundary_release
   bucket_name             = var.bucket_name
   desired_capacity        = var.desired_capacity

--- a/modules/worker/variables.tf
+++ b/modules/worker/variables.tf
@@ -1,3 +1,9 @@
+variable "bastion_security_group" {
+  default     = ""
+  description = "The ID of the bastion security group"
+  type        = string
+}
+
 variable "boundary_release" {
   default     = "0.1.0"
   description = "The version of Boundary to install"

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "controller_min_size" {
   type        = number
 }
 
+variable "key_name" {
+  default     = ""
+  description = "The name of the key pair"
+  type        = string
+}
+
 variable "private_subnets" {
   default     = []
   description = "List of private subnets"


### PR DESCRIPTION
This commit will create a bastion host if the user provides a value for
the `key_name` input variable.

The bastion host by default allows TCP traffic on port 22 from anywhere.
However, the worker and controller instances only allow SSH access from
the bastion host security group.