### PR TITLE
:wrench: Remove default aws provider from the main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-provider "aws" {}
-
 locals {
   image_id = data.aws_ami.boundary.id
 


### PR DESCRIPTION
For better compatibility, it is better not to configure the provider inside the module itself.