### PR TITLE
fix: add module version constraints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,4 +2,4 @@ repos:
   - hooks:
       - id: terraform_docs
     repo: "https://github.com/antonbabenko/pre-commit-terraform.git"
-    rev: v1.43.0
+    rev: v1.51.0

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,59 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.59.0"
+  constraints = ">= 2.49.0, ~> 3.0, >= 3.38.0, >= 3.40.0, >= 3.44.0"
+  hashes = [
+    "h1:tuHv/1slRRVPlm6a53fWdIV0oqnBe9cOkr0J9as76Cc=",
+    "zh:0b33154c805071af15839184f3faafeb1549d26a2f1fe721393461790c5ddb46",
+    "zh:1c5c6793cbec328394c6dda686298d9f6bb7b4c6a39e3dc48dc3035dea9aeda0",
+    "zh:20b590b9d9f0a18fdc9f0fb18bb2d9d5349b14039899ecf66e4ae5513606405b",
+    "zh:3e9010dbb0655b5d05e5e98bfe3e1e73cfa5ff6b364dfd73e8eeeb5e1e58c643",
+    "zh:47a46895d2592fbe7c904107ab6af25abbb17de230852859c06eee95ab282823",
+    "zh:615745b8c25b111cfe204d52553ea530d84abba7fb8be6b5b00476184407b556",
+    "zh:701e0f2e5191729601b6d7591e5c3f5d77439125a74116786cca3bc6d7abf0d9",
+    "zh:7217637b5726bfd09dc9b4f75aef643530e8b673f6de6e06f660a70f4d3170e2",
+    "zh:8097811557dd5fffcc77e921d3a49dfaa203d4640ac3859a64dcd927122ade8b",
+    "zh:9a23df54c62dcf74e88aa309700651a6e77e173429ef0307ee15aaa7ff2f47d0",
+    "zh:e5fa052b9285332a1ebb360ab14676bca88efdaac96cdd809207b23f8e732bb0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.0"
+  constraints = ">= 2.2.0, >= 3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ As always, thanks for using this module!
 
 | Name | Version |
 |------|---------|
+| terraform | ~> 1.0 |
 | terraform | >= 0.13 |
 
 ## Providers

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = "~> 1.0"
+}
+
 locals {
   image_id = data.aws_ami.boundary.id
 
@@ -80,7 +84,8 @@ module "workers" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.7.0"
 
   azs                = data.aws_availability_zones.available.names
   cidr               = var.cidr_block

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ module "workers" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.7.0"
+  version = "~> 3.7"
 
   azs                = data.aws_availability_zones.available.names
   cidr               = var.cidr_block

--- a/modules/boundary/README.md
+++ b/modules/boundary/README.md
@@ -1,7 +1,9 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/boundary/outputs.tf
+++ b/modules/boundary/outputs.tf
@@ -1,4 +1,4 @@
 output "auto_scaling_group_name" {
   description = "The name of the controller Auto Scaling group"
-  value       = module.autoscaling.this_autoscaling_group_name
+  value       = module.autoscaling.autoscaling_group_name
 }

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -1,13 +1,15 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 3.0 |
 | random | n/a |
 
 ## Inputs

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -1,11 +1,11 @@
 output "bastion_security_group" {
   description = "The ID of the bastion security group"
-  value       = join("", aws_security_group.bastion[*].id)
+  value       = one(aws_security_group.bastion[*].id)
 }
 
 output "dns_name" {
   description = "The public DNS name of the load balancer"
-  value       = module.alb.this_lb_dns_name
+  value       = module.alb.lb_dns_name
 }
 
 output "ip_addresses" {

--- a/modules/worker/README.md
+++ b/modules/worker/README.md
@@ -1,13 +1,15 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/modules/worker/main.tf
+++ b/modules/worker/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
 locals {
   configuration = templatefile(
     "${path.module}/templates/configuration.hcl.tpl",


### PR DESCRIPTION
This commit adds version constraints to the modules sourced from the Terraform registry.

This commit also includes some minor changes like removing the `join` function in favor of using [`one`](https://www.terraform.io/docs/language/functions/one.html).

Closes #6