### PR TITLE
parameterize engine_version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ module "controllers" {
   boundary_release = var.boundary_release
   bucket_name      = aws_s3_bucket.boundary.id
   desired_capacity = var.controller_desired_capacity
+  engine_version   = var.engine_version
   image_id         = local.image_id
   instance_type    = var.controller_instance_type
   key_name         = var.key_name

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -165,7 +165,7 @@ module "postgresql" {
   backup_retention_period = 0
   backup_window           = "03:00-06:00"
   engine                  = "postgres"
-  engine_version          = "12.4"
+  engine_version          = var.engine_version
   family                  = "postgres12"
   identifier              = "boundary"
   instance_class          = "db.t2.micro"

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -56,13 +56,19 @@ variable "min_size" {
   type        = number
 }
 
+variable "engine_version" {
+  default     = "12.10"
+  description = "The engine_version of the postgres db, within the postgres12 family"
+  type        = string
+}
+
 variable "private_subnets" {
-  description = "List of private subnets"
+  description = "List of private subnet ids"
   type        = list(string)
 }
 
 variable "public_subnets" {
-  description = "List of public subnets"
+  description = "List of public subnet ids"
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "controller_min_size" {
   type        = number
 }
 
+variable "engine_version" {
+  default     = "12.10"
+  description = "The engine_version of the postgres db, within the postgres12 family"
+  type        = string
+}
+
 variable "key_name" {
   default     = ""
   description = "The name of the key pair"


### PR DESCRIPTION
```
% tf version
Terraform v1.1.9
on linux_amd64
+ provider registry.terraform.io/hashicorp/aws v3.75.2
+ provider registry.terraform.io/hashicorp/random v3.3.1
```

As of at least the above versions, I'm unable to apply the terraform due to:

```
│ Error: Error creating DB Instance: InvalidParameterCombination: Cannot find version 12.4 for postgres
│       status code: 400, request id: 5a50a298-f67a-40a0-877b-ec4e419d228b
│ 
│   with module.boundary.module.controllers.module.postgresql.module.db_instance.aws_db_instance.this[0],
│   on .terraform/modules/boundary.controllers.postgresql/modules/db_instance/main.tf line 20, in resource "aws_db_instance" "this":
│   20: resource "aws_db_instance" "this" {
```

The `12.4` [version has been deprecated](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html#postgresql-versions-version12), `12.10` is the latest `12.x` as of this writing.

These few changes parameterize the `engine_version` variable, default to `12.10`, and "pass-through" to the module call. I left the previous assumption of `family = postgres12` in-tact.

This change also updates some var descriptions from "subnets" to "subnet ids" since this is really how they're used (but doesn't change the var names themselves).

I was able to apply this module with these changes. 

Thanks for the module! 